### PR TITLE
fix main field of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "charts"
   ],
   "license": "MIT",
-  "main": "index",
+  "main": "dist/commonjs/index.js",
   "repository": {
     "type": "git",
     "url": "http://github.com/grofit/aurelia-chart"


### PR DESCRIPTION
Hi,

to use this plugin with [aurelia-webpack,](https://github.com/aurelia/webpack-plugin), the main field of `package.json` should point to `dist/commonjs/index.js`. 
Then it's a matter of specifying the following in your `webpack.config.js`:

``` js
{
  plugins: [
    new AureliaWebpackPlugin({
      includeSubModules: [{ moduleId: 'aurelia-chart' }]
    })
  ],
  alias: {
    'chartjs': 'chart.js'
  }
}
```

This might be something worth adding to the readme :smiley: 
