### PR TITLE
fix(chart-element): use PLATFORM.moduleName

### DIFF
--- a/packages/aurelia-chart/src/elements/chart-element.ts
+++ b/packages/aurelia-chart/src/elements/chart-element.ts
@@ -1,10 +1,10 @@
-import { inject, customElement, useView, bindable, bindingMode } from 'aurelia-framework';
+import { inject, customElement, useView, bindable, bindingMode, PLATFORM } from 'aurelia-framework';
 import { ModelObserver } from '../observers/model-observer';
 import { Chart, ChartConfiguration, ChartData, ChartOptions, ChartType } from 'chart.js';
 
 @customElement('chart')
 @inject(ModelObserver)
-@useView('./chart-element.html')
+@useView(PLATFORM.moduleName('./chart-element.html'))
 export class ChartElement {
   @bindable
   type: ChartType;


### PR DESCRIPTION
Always missed this. Allows for `webpack.config` simplification in consumer apps.
No rush with the merge, it's just a "nice to have".