### PR TITLE
fix(chart-element): do not clone data

### DIFF
--- a/packages/aurelia-chart/src/attributes/chart-attribute.ts
+++ b/packages/aurelia-chart/src/attributes/chart-attribute.ts
@@ -5,14 +5,39 @@ import { Chart, ChartOptions, ChartData, ChartConfiguration, ChartType } from 'c
 @customAttribute('chart')
 @inject(Element, ModelObserver)
 export class ChartAttribute {
+  constructor(private element: HTMLCanvasElement, private modelObserver: ModelObserver) { }
+
+  activeChart?: Chart;
+  private chartData: ChartConfiguration;
+
   @bindable
   type: ChartType;
+  typeChanged() {
+    this.chartData.type = this.type;
+    if (this.isObserving) {
+      this.refreshChart();
+      this.modelObserver.unsubscribe();
+      this.subscribeToChanges();
+    }
+  }
 
   @bindable
   data: ChartData;
+  dataChanged() {
+    this.chartData.data = this.data;
+    if (this.isObserving) {
+      this.refreshChart();
+      this.modelObserver.unsubscribe();
+      this.subscribeToChanges();
+    }
+  }
 
   @bindable
   shouldUpdate: boolean | string;
+
+  private get isObserving() {
+    return this.shouldUpdate === true || this.shouldUpdate === 'true';
+  }
 
   @bindable
   throttle?: number;
@@ -20,64 +45,44 @@ export class ChartAttribute {
   @bindable({ defaultBindingMode: bindingMode.twoWay })
   nativeOptions: ChartOptions = {};
 
-  _activeChart: Chart;
-  _isSetup = false;
-  _chartData: ChartConfiguration;
-
-  constructor(private element: HTMLCanvasElement, private _modelObserver: ModelObserver) { }
+  bind() {
+    // prevent initial changed handlers call
+  }
 
   attached() {
-    this.createChart();
-    this._isSetup = true;
-    if (this._isObserving) {
+    this.chartData = {
+      type: this.type,
+      data: this.data,
+      options: this.nativeOptions
+    };
+
+    this.activeChart = new Chart(this.element, this.chartData);
+    this.nativeOptions = this.activeChart.options;
+    this.refreshChart();
+
+    if (this.isObserving) {
       this.subscribeToChanges();
     }
   }
 
   detached() {
-    if (this._isObserving) {
-      this._modelObserver.unsubscribe();
+    if (this.isObserving) {
+      this.modelObserver.unsubscribe();
     }
-    this._activeChart.destroy();
-    this._isSetup = false;
-  }
 
-  get _isObserving() {
-    return this.shouldUpdate === true || this.shouldUpdate === 'true';
-  }
-
-  get _clonedData(): ChartData {
-    return JSON.parse(JSON.stringify(this.data)) as ChartData;
-  }
-
-  createChart() {
-    this._chartData = {
-      type: this.type,
-      data: this._clonedData,
-      options: this.nativeOptions
-    };
-
-    this._activeChart = new Chart(this.element, this._chartData);
-    this.nativeOptions = this._activeChart.options;
-    this.refreshChart();
-  }
-
-  propertyChanged() {
-    if (this._isSetup && this._isObserving) {
-      this.refreshChart();
-      this._modelObserver.unsubscribe();
-      this.subscribeToChanges();
-    }
+    this.activeChart?.destroy();
+    this.activeChart = undefined;
   }
 
   refreshChart = () => {
-    this._chartData.data = this._clonedData;
-    this._activeChart.update();
-    this._activeChart.resize();
+    if (this.activeChart) {
+      this.activeChart.update();
+      this.activeChart.resize();
+    }
   };
 
   subscribeToChanges() {
-    this._modelObserver.throttle = this.throttle ?? 100;
-    this._modelObserver.observe(this.data, this.refreshChart);
+    this.modelObserver.throttle = this.throttle ?? 100;
+    this.modelObserver.observe(this.data, this.refreshChart);
   }
 }

--- a/packages/aurelia-chart/src/index.ts
+++ b/packages/aurelia-chart/src/index.ts
@@ -8,3 +8,5 @@ export function configure(aurelia: FrameworkConfiguration) {
   ]);
   aurelia.container.registerTransient(ModelObserver);
 }
+
+export { ChartElement } from './elements/chart-element';

--- a/packages/aurelia-chart/src/observers/model-observer.ts
+++ b/packages/aurelia-chart/src/observers/model-observer.ts
@@ -4,23 +4,23 @@ import { BindingEngine, inject, Disposable, CollectionObserver } from 'aurelia-f
 export class ModelObserver {
   throttle = 100;
 
-  _throttleTimeout?: ReturnType<typeof setTimeout>;
-  _activeSubscriptions: Disposable[] = [];
+  private throttleTimeout?: ReturnType<typeof setTimeout>;
+  private activeSubscriptions: Disposable[] = [];
 
   constructor(private bindingEngine: BindingEngine) { }
 
   observe = (model: unknown, onChange: () => void) => {
     const subscriptions: CollectionObserver['subscribe'][] = [];
-    this._getAllSubscriptions(model, subscriptions);
+    this.getAllSubscriptions(model, subscriptions);
 
     const throttledHandler = () => {
       if (this.throttle <= 0) {
         return onChange();
       }
 
-      if (!this._throttleTimeout) {
-        this._throttleTimeout = setTimeout(() => {
-          this._throttleTimeout = undefined;
+      if (!this.throttleTimeout) {
+        this.throttleTimeout = setTimeout(() => {
+          this.throttleTimeout = undefined;
           onChange();
         }, this.throttle);
       }
@@ -28,19 +28,19 @@ export class ModelObserver {
 
     for (let i = 0; i < subscriptions.length; i++) {
       const outstandingSubscription = subscriptions[i](throttledHandler);
-      this._activeSubscriptions.push(outstandingSubscription);
+      this.activeSubscriptions.push(outstandingSubscription);
     }
   };
 
   unsubscribe = () => {
-    for (let i = 0; i < this._activeSubscriptions.length; i++) {
-      this._activeSubscriptions[i].dispose();
+    for (let i = 0; i < this.activeSubscriptions.length; i++) {
+      this.activeSubscriptions[i].dispose();
     }
 
-    this._activeSubscriptions = [];
+    this.activeSubscriptions = [];
   };
 
-  _getObjectType(obj: unknown) {
+  private getObjectType(obj: unknown) {
     if (obj instanceof Date) {
       return 'date';
     } else if (obj instanceof Array) {
@@ -50,17 +50,17 @@ export class ModelObserver {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  _getAllSubscriptions(model: any, subscriptions: CollectionObserver['subscribe'][]) {
+  private getAllSubscriptions(model: any, subscriptions: CollectionObserver['subscribe'][]) {
     if (model instanceof Array) {
       const subscription = this.bindingEngine.collectionObserver(model).subscribe;
       subscriptions.push(subscription);
     }
 
     for (const property in model) {
-      const typeOfData = this._getObjectType(model[property]);
+      const typeOfData = this.getObjectType(model[property]);
       switch (typeOfData) {
         case 'object':
-          this._getAllSubscriptions(model[property], subscriptions);
+          this.getAllSubscriptions(model[property], subscriptions);
           break;
         // case 'array': {
         //   const underlyingArray = model[property]() as unknown[];


### PR DESCRIPTION
Cloning prevents using scriptable options in datasets and proper updates.

I've also cleaned up some code.